### PR TITLE
Raise NoIPControl error when IP Control is disabled or TV is not supported

### DIFF
--- a/bravia_tv/braviarc.py
+++ b/bravia_tv/braviarc.py
@@ -127,7 +127,7 @@ class BraviaRC:
                                      cookies=self._cookies,
                                      timeout=timeout)
             if response.status_code == 404:
-                raise NoIPControl("IP Control not enabled or TV is not supported")
+                raise NoIPControl("IP Control is not enabled or TV is not supported")
         except requests.exceptions.HTTPError as exception_instance:
             if log_errors:
                 _LOGGER.error("HTTPError: " + str(exception_instance))

--- a/bravia_tv/braviarc.py
+++ b/bravia_tv/braviarc.py
@@ -127,7 +127,7 @@ class BraviaRC:
                                      cookies=self._cookies,
                                      timeout=timeout)
             if response.status_code == 404:
-                raise NoIPControl("IP Control not enabled or TV not supported")
+                raise NoIPControl("IP Control not enabled or TV is not supported")
         except requests.exceptions.HTTPError as exception_instance:
             if log_errors:
                 _LOGGER.error("HTTPError: " + str(exception_instance))
@@ -369,7 +369,7 @@ class BraviaRC:
 
 
 class NoIPControl(Exception):
-    """Raised when IP Control is not enabled/not supported."""
+    """Raised when IP Control is not enabled/TV is not supported."""
 
     def __init__(self, status):
         """Initialize."""

--- a/bravia_tv/braviarc.py
+++ b/bravia_tv/braviarc.py
@@ -127,7 +127,7 @@ class BraviaRC:
                                      cookies=self._cookies,
                                      timeout=timeout)
             if response.status_code == 404:
-                raise NoIPControl("IP Control not enabled or not supported")
+                raise NoIPControl("IP Control not enabled or TV not supported")
         except requests.exceptions.HTTPError as exception_instance:
             if log_errors:
                 _LOGGER.error("HTTPError: " + str(exception_instance))

--- a/bravia_tv/braviarc.py
+++ b/bravia_tv/braviarc.py
@@ -126,6 +126,8 @@ class BraviaRC:
                                      headers=headers,
                                      cookies=self._cookies,
                                      timeout=timeout)
+            if response.status_code == 404:
+                raise NoIPControl("IP Control not enabled or not supported")
         except requests.exceptions.HTTPError as exception_instance:
             if log_errors:
                 _LOGGER.error("HTTPError: " + str(exception_instance))
@@ -364,3 +366,12 @@ class BraviaRC:
             self._mac = self._system_info.get('macAddr')
             self._uid = self._system_info.get('cid')
             return self._system_info
+
+
+class NoIPControl(Exception):
+    """Raised when IP Control is not enabled/not supported."""
+
+    def __init__(self, status):
+        """Initialize."""
+        super(NoIPControl, self).__init__(status)
+        self.status = status


### PR DESCRIPTION
Currently, when the TV has IP Control disabled or the TV is not supported, the `JSONDecodeError` exception is raised when method `connect` is used.
This patch checks if the requests `status_code` is `404` and if so raises a `NOIPControl` exception that could be handled by HA integration.

Related issue: https://github.com/home-assistant/core/issues/35126