### PR TITLE
Added ability to change video modes (scenes).

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,16 @@ Command Examples
         # Start a given app
         braviarc.start_app("Netflix")
 
+        # Get scenes (video modes)
+        scenes = braviarc.load_scene_list()
+        print (scenes)
+
+        # Get current scene (video mode)
+        current_scene = braviarc.get_current_scene()
+        print (current_scene)
+
+        # Set scene (video mode) to 'Cinema'
+        braviarc.set_scene('Cinema')
+
         # Turn off the TV
         braviarc.turn_off()


### PR DESCRIPTION
I'd like to change video modes via automations in home assistant, so I'd be able to change the picture mode to "Game" to disable post processing when gaming on my Bravia TV.

Next step would be extending the media_player & braviatv component in the home-assistant core to allow support for changing video modes similar to changing sound modes for audio players.